### PR TITLE
- Added support for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.6)
 
-project(snet-gateway)
+set (PROJECT_NAME "snet-gateway" CXX)
+project(${PROJECT_NAME})
 
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
@@ -13,10 +14,14 @@ else()
     message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
 endif()
 
-# Add custom cxx flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wextra")
-
+if(MSVC)	
+	#set(BOOST_ROOT C:/Boost) #specify coustom boost directory		
+	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})
+else()
+	# Add custom cxx flags
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wextra")
+endif()
 # Automatically set the version number
 set(SNET_GATEWAY_VERSION_MAJOR \"1\")
 set(SNET_GATEWAY_VERSION_MINOR \"6pre\")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,12 @@
-set(Boost_USE_STATIC_LIBS OFF) 
-set(Boost_USE_MULTITHREADED ON)  
-set(Boost_USE_STATIC_RUNTIME OFF) 
-find_package(Boost REQUIRED COMPONENTS system signals program_options regex)
+if(MSVC)
+    set(Boost_USE_STATIC_LIBS ON)     
+    find_package(Boost REQUIRED COMPONENTS system signals program_options date_time regex)
+else()
+    set(Boost_USE_STATIC_LIBS OFF) 
+    set(Boost_USE_MULTITHREADED ON)  
+    set(Boost_USE_STATIC_RUNTIME OFF) 
+    find_package(Boost REQUIRED COMPONENTS system signals program_options regex)
+endif()
 include_directories(${Boost_INCLUDE_DIR})
 include_directories(
     "HdlcdClient"
@@ -16,7 +21,7 @@ include_directories(
     
 find_package(Threads)
 
-add_executable(snet-gateway
+add_executable(${PROJECT_NAME}
     main-snet-gateway.cpp
     HdlcdClient/HdlcdClientHandler.cpp
     HdlcdClient/HdlcdClientHandlerCollection.cpp
@@ -36,10 +41,10 @@ else()
     set(ADDITIONAL_LIBRARIES "")
 endif()
 
-target_link_libraries(snet-gateway
+target_link_libraries(${PROJECT_NAME}
     ${Boost_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${ADDITIONAL_LIBRARIES}
 )
 
-install(TARGETS snet-gateway RUNTIME DESTINATION bin)
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)


### PR DESCRIPTION
Hi Florian,

I changed the CMakeLists.txt again and commented my „set(BOOST_ROOR)“.

I did leave it there because it becomes necessary the moment you are on windows and have MinGW and Visual Studio installed. Because the find_package(Boost …) will always find it first in MinGW even if it’s in the default boost install directory for windows (C:\Boost). 
And then it won’t work because of file endings. 

Best regards

Max
